### PR TITLE
Add `@apollo/client` as a peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,16 @@ This library includes a `subscriptions` module to provide simple setup using the
 
 The testing submodule exports utility functions for easily constructing ApolloClient instances for integration testing on NodeJS. The `errorPolicy` is set to `all` so that returned errors can be checked.
 
+### Setup
+
+If you use this module, you need to install `@apollo/client`:
+
+```
+npm install --save-dev @apollo/client
+```
+
+### Usage
+
 - `createTestClient` accepts a url and optional accessToken.
 - `createTestClientWithClientCredentials` accepts a url and client credentials config and will fetch and attach an access token to each request.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@makerx/graphql-core",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@makerx/graphql-core",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@makerx/node-common": "^1.0.3",
@@ -46,6 +46,7 @@
         "node": ">=16.0"
       },
       "peerDependencies": {
+        "@apollo/client": "*",
         "express": "*",
         "graphql": "*",
         "graphql-shield": "*",

--- a/package.json
+++ b/package.json
@@ -35,10 +35,11 @@
     "lodash.pick": "^4.4.0"
   },
   "peerDependencies": {
-    "graphql-shield": "*",
+    "@apollo/client": "*",
     "express": "*",
-    "graphql": "*",
+    "graphql-shield": "*",
     "graphql-ws": "*",
+    "graphql": "*",
     "ws": "*"
   },
   "peerDependenciesMeta": {
@@ -63,11 +64,12 @@
     "@types/ws": "^8.5.5",
     "better-npm-audit": "^3.7.3",
     "copyfiles": "^2.4.1",
+    "eslint-plugin-prettier": "5.0.0-alpha.2",
     "eslint": "8.45.0",
     "express": "^4.18.2",
-    "graphql": "^16.7.1",
     "graphql-shield": "^7.6.5",
     "graphql-ws": "^5.14.0",
+    "graphql": "^16.7.1",
     "node-fetch": "^3.3.1",
     "npm-run-all": "^4.1.5",
     "prettier": "3.0.0",
@@ -75,8 +77,7 @@
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1",
     "typescript": "^5.1.6",
-    "ws": "^8.13.0",
-    "eslint-plugin-prettier": "5.0.0-alpha.2"
+    "ws": "^8.13.0"
   },
   "overrides": {
     "@typescript-eslint/eslint-plugin": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,9 @@
     "ws": "*"
   },
   "peerDependenciesMeta": {
+    "@apollo/client": {
+      "optional": true
+    },
     "graphql-ws": {
       "optional": true
     },


### PR DESCRIPTION
## What

Add `@apollo/client` as a peer dependency.

## Why

I got an error on a client project:

```
[1]   ● Test suite failed to run
[1] 
[1]     Cannot find module '@apollo/client/core' from '../node_modules/@makerx/graphql-core/testing.js'
[1] 
[1]     Require stack:
[1]       /home/runner/work/eventsair-api/eventsair-api/graphql/node_modules/@makerx/graphql-core/testing.js
[1]       tests/test-clients.ts
[1]       features/events/tests/event-queries.test.ts
[1] 
[1]     > 1 | import { createTestClient, createTestClientWithClientCredentials } from '@makerx/graphql-core/testing'
[1]         | ^
[1]       2 | import config from '../config'
[1]       3 |
[1]       4 | export const adminTestClient = createTestClientWithClientCredentials(
[1] 
[1]       at Resolver._throwModNotFoundError (../node_modules/jest-resolve/build/resolver.js:427:11)
[1]       at Object.<anonymous> (../node_modules/@makerx/src/testing.ts:1:1)
[1]       at Object.<anonymous> (tests/test-clients.ts:1:1)
[1]       at Object.<anonymous> (features/events/tests/event-queries.test.ts:1:1)
```

I looked at the PR branch:

```
λ npm ls @apollo/client
eventsair-graphql-api@1.0.0 C:\Users\me\dev\eventsair\api\graphql
`-- (empty)
```

Then at `main`:

```
λ npm ls @apollo/client
eventsair-graphql-api@1.0.0 C:\Users\me\dev\eventsair\api\graphql
`-- graphql-tools@9.0.0
  `-- @apollo/client@3.7.17
```

I did remove `graphql-tools` in my PR as it's been deprecated in favour of new packages under the `@graphql-tools` scope.