### PR TITLE
Use the built-in `req.hostname` property

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -100,7 +100,7 @@ export const createContextFactory = <TContext extends AnyGraphqlContext = GraphQ
     const baseRequestInfo: BaseRequestInfo = {
       requestId: req.headers['x-request-id']?.toString() ?? randomUUID(),
       protocol: req.protocol as 'http' | 'https',
-      host: req.get('Host') ?? '',
+      host: req.hostname ?? '',
       method: req.method ?? '',
       url: req.originalUrl,
       origin: req.get('Origin') ?? '',


### PR DESCRIPTION
_Note: I opened a PR because it's a one-liner, but let's treat this as a discussion_

## What

Use the built-in `req.hostname` property instead of `req.get('Host')`.

## Why

It seems there's some smarts behind the implementation, namely around:

- Sourcing it from `X-Forwarded-Host` if the `trust proxy` setting is enabled
- IPv6 support
- Catering for when the header has multiple values

See the code here: <https://github.com/expressjs/express/blob/4.x/lib/request.js#L416-L450>.

Thoughts?