### PR TITLE
Support subscription operation logging with custom log level

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": true,
+    "source.organizeImports": true
   }
 }

--- a/README.md
+++ b/README.md
@@ -119,20 +119,11 @@ const graphqlServer = createServer({
 
 ### logGraphQLOperation
 
-The `logGraphQLOperation` function will log:
+Logs a GraphQL operation in a consistent format with the option of including any additional data. Top level and result level log data with null or undefined values will be omitted for berevity.
 
-- `operationName`: the operation name, if supplied
-- `query`: the formatted graphql query or mutation, or 'IntrospectionQuery'
-- `variables`: the graphql request variables
-- `duration`: the duration of request processing
-- `errors`: the graphql response errors, if any
+Refer to the `GraphQLLogOperationInfo` type for the definition of input.
 
-Notes:
-
-- null or undefined values will be omitted
-- introspection queries will not be logged outside of production
-
-This function can be used across implementations, e.g. in a [GraphQL Envelop plugin](https://www.envelop.dev/docs/plugins) or [ApolloServer plugin](https://www.apollographql.com/docs/apollo-server/integrations/plugins/).
+This function can be used across implementations, e.g. in a [GraphQL Envelop plugin](https://www.envelop.dev/docs/plugins) or [ApolloServer plugin](https://github.com/MakerXStudio/graphql-apollo-server/blob/main/src/plugins/graphql-operation-logging-plugin.ts).
 
 ## GraphQL subscriptions
 

--- a/README.md
+++ b/README.md
@@ -134,12 +134,6 @@ Notes:
 
 This function can be used across implementations, e.g. in a [GraphQL Envelop plugin](https://www.envelop.dev/docs/plugins) or [ApolloServer plugin](https://www.apollographql.com/docs/apollo-server/integrations/plugins/).
 
-### logGraphQLExecutionArgs
-
-The `logGraphQLExecutionArgs` will log `operationName`, `query` and `variables` params from the GraphQL `ExecutionArgs`.
-
-This can be used when logging from execution callbacks, e.g. graphql-ws Server [onOperation](https://the-guild.dev/graphql/ws/docs/interfaces/server.ServerOptions#onoperation) and [onNext](https://the-guild.dev/graphql/ws/docs/interfaces/server.ServerOptions#onnext).
-
 ## GraphQL subscriptions
 
 This library includes a `subscriptions` module to provide simple setup using the [GraphQL WS](https://the-guild.dev/graphql/ws) package.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@makerx/graphql-core",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": false,
   "description": "A set of core GraphQL utilities that MakerX uses to build GraphQL APIs",
   "author": "MakerX",

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,55 +1,81 @@
 import { isLocalDev, Logger } from '@makerx/node-common'
-import { ExecutionArgs, GraphQLFormattedError, print } from 'graphql'
+import { ExecutionArgs, GraphQLFormattedError, OperationTypeNode, print } from 'graphql'
+import { ExecutionResult } from 'graphql-ws'
 import omitBy from 'lodash.omitby'
-import { isIntrospectionQuery, isNil } from './utils'
 import { GraphQLContext } from './context'
+import { isIntrospectionQuery, isNil } from './utils'
 
-interface GraphQLLogOperationInfo {
-  started: number
+interface GraphQLLogOperationInfo<TLogger extends Logger = Logger> {
+  message?: string
+  started?: number
+  type?: OperationTypeNode | null
   operationName?: string | null
   query?: string | null
   variables?: Record<string, unknown> | null
-  result: {
+  result?: {
     data?: Record<string, unknown> | null
     errors?: readonly GraphQLFormattedError[] | null
+    hasNext?: boolean
   }
-  logger: Logger
+  logger: TLogger
+  logLevel?: keyof TLogger
 }
 
-export const logGraphQLOperation = ({ started, operationName, query, variables, result: { errors }, logger }: GraphQLLogOperationInfo) => {
+export const logGraphQLOperation = <TLogger extends Logger = Logger>({
+  message = 'GraphQL operation',
+  started,
+  type,
+  operationName,
+  query,
+  variables,
+  result,
+  logger,
+  logLevel = 'info',
+}: GraphQLLogOperationInfo<TLogger>) => {
   const isIntrospection = query && isIntrospectionQuery(query)
   if (isLocalDev && isIntrospection) return
-  logger.info(
-    'GraphQL operation',
-    omitBy(
-      {
-        operationName,
-        query: isIntrospection ? 'IntrospectionQuery' : query,
-        variables: variables && Object.keys(variables).length > 0 ? variables : undefined,
-        duration: Date.now() - started,
-        errors,
-      },
-      isNil,
-    ),
-  )
-}
-
-/**
- * Logs `operationName`, `query` and `variables` params from the GraphQL `ExecutionArgs`.
- * If `args.contextValue` has a `logger` property, it will be used, otherwise the `logger` param will be used.
- */
-export const logGraphQLExecutionArgs = (args: ExecutionArgs, message: string, logger?: Logger) => {
-  const { operationName, variableValues, document } = args
-  const contextLogger = (args.contextValue as Partial<GraphQLContext>).logger ?? logger
-  contextLogger?.info(
+  logger[logLevel as keyof Logger](
     message,
     omitBy(
       {
+        type,
         operationName,
-        query: print(document),
-        variables: variableValues,
+        query,
+        variables: variables && Object.keys(variables).length > 0 ? variables : undefined,
+        duration: started ? Date.now() - started : undefined,
+        result: result ? omitBy(result, isNil) : undefined,
+        isIntrospectionQuery: isIntrospection || undefined,
       },
       isNil,
     ),
   )
+}
+
+export const logSubscriptionOperation = <TLogger extends Logger = Logger>({
+  args,
+  result,
+  message,
+  logLevel,
+}: {
+  args: ExecutionArgs
+  result?: ExecutionResult
+  message?: string
+  logLevel?: keyof TLogger
+}) => {
+  const logger = (args.contextValue as GraphQLContext).logger as TLogger
+  if (!logger) return
+
+  const { operationName, variableValues, document } = args
+  const { data, ...resultWithoutData } = result ?? {}
+
+  logGraphQLOperation({
+    message,
+    type: OperationTypeNode.SUBSCRIPTION,
+    operationName,
+    query: print(document),
+    variables: variableValues,
+    result: resultWithoutData,
+    logger,
+    logLevel,
+  })
 }

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -5,8 +5,9 @@ import omitBy from 'lodash.omitby'
 import { GraphQLContext } from './context'
 import { isIntrospectionQuery, isNil } from './utils'
 
+type LogFunction = Logger['info']
 export type LoggerLogFunctions<T extends Logger> = {
-  [Property in keyof T]: (message: string, ...optionalParams: unknown[]) => void
+  [Property in keyof T]: LogFunction
 }
 
 /**

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -114,7 +114,7 @@ export const logSubscriptionOperation = <TLogger extends Logger = Logger>({
   args: ExecutionArgs
   result?: ExecutionResult
   message?: string
-  logLevel?: keyof TLogger
+  logLevel?: keyof LoggerLogFunctions<TLogger>
 }) => {
   const logger = (args.contextValue as GraphQLContext).logger as TLogger
   if (!logger) return


### PR DESCRIPTION
# What ?

Over in the graphql-apollo-server lib we recently [tweaked the graphql operation logging plugin](https://github.com/MakerXStudio/graphql-apollo-server/pull/141) to support a little more output plus make the log level configurable.

This PR:
- makes the log level for logging subscription operations configurable (e.g. we might wish to log them as `audit`)
- logs subscription operations using the `logGraphQLOperation` method via `logSubscriptionOperation`, aligning output somewhat to what the `graphql-apollo-server#graphqlOperationLoggingPlugin` produces